### PR TITLE
Changed run.sh to remove agent if installing a server

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -88,6 +88,13 @@ if [ "${INSTALL_RKE2_SKIP_ENABLE}" = true ]; then
     exit 0
 fi
 
+if [ "${INSTALL_RKE2_TYPE}" = "server" ]  && systemctl is-active --quiet rke2-agent; then
+    systemctl stop rke2-agent
+    systemctl disable rke2-agent
+    systemctl reset-failed rke2-agent
+    rm "${SYSTEMD_BASE_PATH}/rke2-agent.service"
+fi
+
 systemctl enable "rke2-${INSTALL_RKE2_TYPE}"
 
 if [ "${INSTALL_RKE2_SKIP_START}" = true ]; then

--- a/package/run.sh
+++ b/package/run.sh
@@ -92,7 +92,6 @@ if [ "${INSTALL_RKE2_TYPE}" = "server" ]  && systemctl is-active --quiet rke2-ag
     systemctl stop rke2-agent
     systemctl disable rke2-agent
     systemctl reset-failed rke2-agent
-    rm "${SYSTEMD_BASE_PATH}/rke2-agent.service"
 fi
 
 systemctl enable "rke2-${INSTALL_RKE2_TYPE}"


### PR DESCRIPTION
This is a fix for https://github.com/rancher/rke2/issues/1721 and https://github.com/rancher/rancherd/issues/5
If rke2-server is going to run and rke2-agent already exists, stop and disable the agent first.

## Verification
Spin up two nodes
Run `rancherd bootstrap` on both, one as `cluster-init` another as `agent`.
For the agent node, force a role change by editing the yaml in 
`Rancher- UI>More Resources->Cluster Provisioning->Machines`
Add
```
 rke.cattle.io/control-plane-role: "true"
 rke.cattle.io/etcd-role: "true"
```
Under the labels

See on node2 that the `rke2-agent` service stops and is disabled, and that the `rke2-server` service is now enabled
```
root@node-2-buster64:/home/vagrant# systemctl status rke2-agent
● rke2-agent.service - Rancher Kubernetes Engine v2 (agent)
   Loaded: loaded (/usr/local/lib/systemd/system/rke2-agent.service; disabled; vendor preset: enabled)
   Active: inactive (dead) since Thu 2021-09-02 23:35:04 UTC; 1min 2s ago
...
root@node-2-buster64:/home/vagrant# systemctl status rke2-server
● rke2-server.service - Rancher Kubernetes Engine v2 (server)
   Loaded: loaded (/usr/local/lib/systemd/system/rke2-server.service; enabled; vendor preset: enabled)
   Active: active (running) since Thu 2021-09-02 23:35:53 UTC; 19s ago
```
Also the rancher UI now displays two server nodes
![image](https://user-images.githubusercontent.com/11727736/131929608-ff22be6b-2e69-4abf-8c7d-d761f6012d3f.png)



Signed-off-by: dereknola derek.nola@suse.com