### PR TITLE
Passing configuration as parameters instead of environment variables.

### DIFF
--- a/package/run.ps1
+++ b/package/run.ps1
@@ -95,9 +95,7 @@ if ((Get-Service -Name $rke2ServiceName -ErrorAction SilentlyContinue)) {
 }
 
 # if service doesn't exist, then install, otherwise check the binary and determine if it needs to be reinstalled, otherwise fall through to restart, skil enable, skip start
-$env:INSTALL_RKE2_ARTIFACT_PATH = $env:CATTLE_AGENT_EXECUTION_PWD
-$env:INSTALL_RKE2_TAR_PREFIX = $SA_INSTALL_PREFIX 
-./installer.ps1
+./installer.ps1 -TarPrefix $SA_INSTALL_PREFIX  -ArtifactPath $env:CATTLE_AGENT_EXECUTION_PWD
 
 if ($env:RESTART_STAMP) {
     Set-Content -Path $env:RESTART_STAMP_FILE -Value $env:RESTART_STAMP


### PR DESCRIPTION
Changes in the RKE2 script where not accounted for in the run.ps1 causing this issue. Passing the config via parameters removes this concern.

* https://github.com/rancher/rancher/issues/35740

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>