### PR TITLE
Fixed mountpoint check

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -6,7 +6,7 @@ SA_INSTALL_PREFIX="/usr/local"
 
 # check_target_mountpoint return success if the target directory is on a dedicated mount point
 check_target_mountpoint() {
-    mountpoint -q "${PREFIX}"
+    mountpoint -q "${SA_INSTALL_PREFIX}"
 }
 
 # check_target_ro returns success if the target directory is read-only


### PR DESCRIPTION
Replaced unused and non-existing variable `PREFIX` with `SA_INSTALL_PREFIX`. This caused RKE2 to be installed in the default location `/usr/local` even though it was a mount point, which could result in RKE2 not being started after a reboot.

https://github.com/rancher/rancher/issues/38106
https://github.com/rancher/rke2/issues/3001