### PR TITLE
Tweak windows clone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -145,8 +145,10 @@ platform:
   arch: amd64
   version: 1809
 
-steps:
+clone:
+  depth: 1
 
+steps:
   - name: download-windows-1809-amd64
     image: mcr.microsoft.com/windows/servercore:1809-amd64
     environment:
@@ -221,15 +223,9 @@ platform:
   version: 2022
 
 clone:
-  disable: true
+  depth: 1
 
 steps:
-
-  - name: clone
-    image: rancher/drone-images:git-amd64-ltsc2022
-    settings:
-      depth: 1
-
   - name: download-windows-ltsc2022-amd64
     image: mcr.microsoft.com/windows/servercore:ltsc2022-amd64
     environment:


### PR DESCRIPTION
The drone/git powershell scripts ([clone-pull-request](https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-pull-request.ps1#L12) et al) are broken.

If FLAGS are empty then it barfs on the command `git fetch $FLAGS origin "+refs/tags/${Env:DRONE_TAG}:"`. The same is true on Linux:
```console
brandond@dev01:~/go/src/github.com/rancher/system-agent-installer-rke2$ git fetch "" rancher "+refs/tags/foo:"
fatal: no path specified; see 'git help pull' for valid url syntax
```
- which is the exact same error it’s bombing out on currently.

If you set the depth in the clone config then there are flags and the command works:
```console
brandond@dev01:~/go/src/github.com/rancher/system-agent-installer-rke2$ git fetch "--depth=1" rancher "+refs/tags/v1.26.0-rc2+rke2r1:"
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From github.com:rancher/system-agent-installer-rke2
 * tag               v1.26.0-rc2+rke2r1 -> FETCH_HEAD
```