### PR TITLE
Fix systemd unit path when /usr/local is subvolume or ro

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -30,7 +30,12 @@ if check_target_mountpoint || check_target_ro; then
     SA_INSTALL_PREFIX="/opt/rke2"
 fi
 
-SYSTEMD_BASE_PATH="${SA_INSTALL_PREFIX}/lib/systemd/system"
+if [ "${SA_INSTALL_PREFIX}" == "/opt/rke2" ]; then
+    SYSTEMD_BASE_PATH="/etc/systemd/system"
+else
+    SYSTEMD_BASE_PATH="${SA_INSTALL_PREFIX}/lib/systemd/system"
+fi
+
 RKE2_SA_ENV_FILE_PATH="${SAI_FILE_DIR}/${RKE2_SA_ENV_FILE_NAME}"
 RKE2_SA_ENV_SRV_REF="EnvironmentFile=-${RKE2_SA_ENV_FILE_PATH}"
 


### PR DESCRIPTION
If /opt/rke2 is used as the install prefix, the systemd unit is moved to /etc/systemd/system, but the install script didn't account for that when attempting to append the agent's EnvironmentFile line at:

https://github.com/rancher/system-agent-installer-rke2/blob/006cf0313f48b699852176862409d0d291c5e1b0/package/run.sh#L77-L79

This resulted in the agent's env vars not being passed through to RKE2.

* Linked issue: https://github.com/rancher/rke2/issues/3930

More info at https://github.com/rancher/rke2/issues/3930#issuecomment-1440551753
