### PR TITLE
Use posix-compatible = operator

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -30,7 +30,7 @@ if check_target_mountpoint || check_target_ro; then
     SA_INSTALL_PREFIX="/opt/rke2"
 fi
 
-if [ "${SA_INSTALL_PREFIX}" == "/opt/rke2" ]; then
+if [ "${SA_INSTALL_PREFIX}" = "/opt/rke2" ]; then
     SYSTEMD_BASE_PATH="/etc/systemd/system"
 else
     SYSTEMD_BASE_PATH="${SA_INSTALL_PREFIX}/lib/systemd/system"


### PR DESCRIPTION
Fixes error found by @rancher-max:

```
+ mountpoint -q /usr/local"
+ echo /usr/local is ro or a mount point"
+ SA_INSTALL_PREFIX=/opt/rke2"
+ [ /opt/rke2 == /opt/rke2 ]"
/var/lib/rancher/agent/work/20230307-235342/e24b3c1c5ea4701b0c81669114017bfd29f5e7cc4857ed2b759aed465e492c3e_0/run.sh: 33: [: /opt/rke2: unexpected operator"
```