### PR TITLE
Add arm64 support to the system-agent-installer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -360,6 +360,7 @@ platform:
   arch: amd64
 depends_on:
   - build-linux-amd64
+  - build-linux-arm64
   - build-windows-1809-amd64
   - build-windows-ltsc2022-amd64
   - build-linux-s390x

--- a/.drone.yml
+++ b/.drone.yml
@@ -62,6 +62,67 @@ steps:
 ---
 kind: pipeline
 type: docker
+name: build-linux-arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+
+  - name: download-linux-arm64
+    image: registry.suse.com/suse/sle15:15.5.36.5.20
+    environment:
+      ARCH: arm64
+    commands:
+      - zypper -n install curl jq git
+      - scripts/download
+
+  - name: build-linux-arm64
+    image: plugins/docker
+    settings:
+      purge: false
+      dry_run: true
+      build_args:
+        - ARCH=arm64
+        - "VERSION=${DRONE_TAG/+/-}"
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      repo: rancher/system-agent-installer-rke2
+      tag: "${DRONE_COMMIT/+/-}-linux-arm64"
+      username:
+        from_secret: docker_username
+    when:
+      event:
+        - pull_request
+
+  - name: publish-linux-arm64
+    image: plugins/docker
+    settings:
+      purge: false
+      build_args:
+        - ARCH=arm64
+        - "VERSION=${DRONE_TAG/+/-}"
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      repo: rancher/system-agent-installer-rke2
+      tag: "${DRONE_TAG/+/-}-linux-arm64"
+      username:
+        from_secret: docker_username
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/tags/*
+      event:
+        - tag
+---
+kind: pipeline
+type: docker
 name: build-linux-s390x
 
 # Hack needed for s390x: https://gist.github.com/colstrom/c2f359f72658aaabb44150ac20b16d7c#gistcomment-3858388

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -4,6 +4,10 @@ manifests:
     platform:
       architecture: amd64
       os: linux
+  - image: rancher/system-agent-installer-rke2:{{replace "+" "-" build.tag}}-linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
   - image: rancher/system-agent-installer-rke2:{{replace "+" "-" build.tag}}-windows-1809-amd64
     platform:
       architecture: amd64

--- a/scripts/download
+++ b/scripts/download
@@ -12,6 +12,12 @@ mkdir -p artifacts
 if [ -z "${LOCAL_ARTIFACTS}" ]; then
     curl -fL https://raw.githubusercontent.com/rancher/rke2/master/install.sh > artifacts/installer.sh
     chmod +x artifacts/installer.sh
+
+    if [[ "${ARCH}" = "arm64" ]] && [[ "${VERSION}" =~ ^v1\.(20|24|25|26)\. ]]; then
+        echo "Skipping arm64 - not supported for this version."
+        exit
+    fi
+
     pushd artifacts
     curl -fL -O -R https://github.com/rancher/rke2/releases/download/${URI_VERSION}/rke2.linux-${ARCH}.tar.gz
     curl -fL -O -R https://github.com/rancher/rke2/releases/download/${URI_VERSION}/sha256sum-${ARCH}.txt

--- a/scripts/version
+++ b/scripts/version
@@ -64,7 +64,7 @@ if [[ -z "$VERSION" ]]; then
     if [[ $(curl -v https://api.github.com/rate_limit | jq -r '.rate.remaining') = 0 ]]; then
         VERSION="${FALLBACK_VERSION}"
     else
-        VERSION=$(curl -v https://api.github.com/repos/rancher/rke2/releases | jq -r '[.[] | select(.assets[] | length > 2)][0].tag_name')
+        VERSION=$(curl -v https://api.github.com/repos/rancher/rke2/releases | jq -r '[.[] | select(.tag_name | contains("-") | not) | select(.assets[] | length > 2)] | sort_by(.tag_name) | .[-1].tag_name')
         if [[ -z "$VERSION" ]]; then # Fall back to a known good RKE2 version because we had an error pulling the latest
             VERSION="${FALLBACK_VERSION}"
         fi


### PR DESCRIPTION
Based on https://github.com/rancher/rke2/issues/817, rke2 greater than version 1.27 supports arm64 so it makes sense to add that support here. rancher/system-agent already has this support.

Closes out https://github.com/rancher/system-agent-installer-rke2/issues/34