### PR TITLE
Fix issues related to powershell commands and regedit when using a proxy

### DIFF
--- a/package/run.ps1
+++ b/package/run.ps1
@@ -81,11 +81,11 @@ if ($PROXY_ENV_INFO) {
 $newHash = Get-StringHash -Value $($newEnv | Out-String)
 if ($newEnv -and ($newHash -ne $currentHash)) {
     if(Test-Path -Path HKLM:SYSTEM\CurrentControlSet\Services\$rke2ServiceName) {
-        Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$rke2ServiceName -Name Environment -Value $([string]$newEnv)
+        Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$rke2ServiceName -Name Environment -Value $newEnv
     }
     else {
         New-Item HKLM:SYSTEM\CurrentControlSet\Services\$rke2ServiceName
-        New-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$rke2ServiceName -Name Environment -PropertyType MultiString -Value $([string]$newEnv)
+        New-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$rke2ServiceName -Name Environment -PropertyType MultiString -Value $newEnv
     }
     $RESTART = $true
 }


### PR DESCRIPTION
## Before this MR 🙁

Missing environment variables `https_proxy` and `no_proxy` appear in the value of the environment variable `http_proxy`.

![rke2 exe](https://github.com/rancher/system-agent-installer-rke2/assets/77958736/f601fec3-1af5-46ae-9a1e-423708dcd422)


## After this MR 😀

The environment variables `http_proxy`, `https_proxy`, and `no_proxy` are all correctly set.

![rke2 exe](https://github.com/rancher/system-agent-installer-rke2/assets/77958736/fc3f695d-998e-4508-b986-05f5d8ddc3fd)

## References

- [PowerShell 7.4 Official Doc - Create a MultiString value in the registry using an array](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-itemproperty?view=powershell-7.4#example-4-create-a-multistring-value-in-the-registry-using-an-array)
- [PowerShell 5.1 Official Doc - Create a MultiString value in the registry using an array](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-itemproperty?view=powershell-5.1#example-4-create-a-multistring-value-in-the-registry-using-an-array)
