### PR TITLE
update the approach to create the manifest list

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,11 +147,16 @@ jobs:
 
       - name: Create Docker manifest
         run: |
+          echo "creating the manifest list that contains only Windows tags to preserve the os.version metadata"
+          docker manifest create ${{ env.IMAGE }}:${{ env.VERSION }} \
+              ${{ env.IMAGE }}:${{ env.VERSION }}-windows-1809-amd64 \
+              ${{ env.IMAGE }}:${{ env.VERSION }}-windows-ltsc2022-amd64 
+          docker manifest push ${{ env.IMAGE }}:${{ env.VERSION }} 
+          
+          echo "updating the manifest list to append Linux tags"
           docker buildx imagetools create --tag ${{ env.IMAGE }}:${{ env.VERSION }} \
-          ${{ env.IMAGE }}:${{ env.VERSION }}-linux-amd64 \
-          ${{ env.IMAGE }}:${{ env.VERSION }}-linux-arm64 \
-          ${{ env.IMAGE }}:${{ env.VERSION }}-windows-1809-amd64 \
-          ${{ env.IMAGE }}:${{ env.VERSION }}-windows-ltsc2022-amd64
+              --append ${{ env.IMAGE }}:${{ env.VERSION }}-linux-amd64 \
+              --append ${{ env.IMAGE }}:${{ env.VERSION }}-linux-arm64
 
       - name: Inspect image
         run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ env.VERSION }}


### PR DESCRIPTION
Problem:

The `platform.os.version` is missing from the Windows manifest in the final tag (manifest list). 

It turns out that the command `docker buildx imagetools create` does not work well to handle the Windows manifests; 
the command `docker manifest create` can preserve the `platform.os.version` value, but does not support creating new manifest lists from a combination of manifests and manifest lists. 


Fix:

We need to split the process of creating a new tag ( manifest list) into two steps:
first, we create the manifest list that contains only Windows tags to preserve the `os.version` metadata;
then, we update the manifest list to append Linux tags. 


Validation:
The CI is validated on my fork and the image `jq20/system-agent-installer-rke2:v1.28.11-rke2r1` is pushed to Dockerhub. 
The workflow run: https://github.com/jiaqiluo/system-agent-installer-rke2/actions/runs/9767129053

The following output shows that the `os.version` info is preserved on the Windows manifest:
```
>  skopeo inspect --raw  docker://jq20/system-agent-installer-rke2:v1.28.11-rke2r1
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "digest": "sha256:a86e2631247a042c328b671729ea3171cc79b6417cbe05d81251634e67c754cc",
      "size": 950,
      "platform": {
        "architecture": "amd64",
        "os": "windows",
        "os.version": "10.0.17763.5936"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "digest": "sha256:131d5ad25b0f2aec94533df7960d9f18ba08288652bd0435090df824f21c7590",
      "size": 950,
      "platform": {
        "architecture": "amd64",
        "os": "windows",
        "os.version": "10.0.20348.2529"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:bde2d1b8cf89b7afe5691800f60be1f4b3d82d58ccd7179c0cbfefa5a8bf72bb",
      "size": 670,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:86642e4a77e851e38b59b1234209eb788c1411a22fa0c6224b79feb3ccdb56a5",
      "size": 566,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:bde2d1b8cf89b7afe5691800f60be1f4b3d82d58ccd7179c0cbfefa5a8bf72bb",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:0405decdbe66cbb53c5911b7d141243866417136d7bf55e87f98f4e0c8e83096",
      "size": 670,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2748b127538a010e62ac877b34c9bd863c8a9c04bee711a87553a9fdf18d5390",
      "size": 566,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:0405decdbe66cbb53c5911b7d141243866417136d7bf55e87f98f4e0c8e83096",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
  ]
}
```
