### PR TITLE
chore: add image text to agent installer

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -20,6 +20,7 @@ if [ -z "${LOCAL_ARTIFACTS}" ]; then
 
     pushd artifacts
     curl -fL -O -R https://github.com/rancher/rke2/releases/download/${URI_VERSION}/rke2.linux-${ARCH}.tar.gz
+    curl -fL -O -R https://github.com/rancher/rke2/releases/download/${URI_VERSION}/rke2-images-core.linux-${ARCH}.txt
     curl -fL -O -R https://github.com/rancher/rke2/releases/download/${URI_VERSION}/sha256sum-${ARCH}.txt
     popd
 else


### PR DESCRIPTION
This is a simple change that also includes the `core` rke2 images inside the image