### PR TITLE
Fix deprecated Windows runner

### DIFF
--- a/.github/workflows/ci-on-pull-requset.yaml
+++ b/.github/workflows/ci-on-pull-requset.yaml
@@ -57,7 +57,7 @@ jobs:
         include:
           - NANOSERVER_VERSION: 1809
             TAG_SUFFIX: windows-1809-amd64
-            RUNNER: windows-2019
+            RUNNER: windows-2022
           - NANOSERVER_VERSION: ltsc2022
             TAG_SUFFIX: windows-ltsc2022-amd64
             RUNNER: windows-2022

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
         include:
           - NANOSERVER_VERSION: 1809
             TAG_SUFFIX: windows-1809-amd64
-            RUNNER: windows-2019
+            RUNNER: windows-2022
           - NANOSERVER_VERSION: ltsc2022
             TAG_SUFFIX: windows-ltsc2022-amd64
             RUNNER: windows-2022


### PR DESCRIPTION
Currently getting this error:
``` 
build-windows (1809, windows-1809-amd64, windows-2019)
Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. 
For more details, see https://github.com/actions/runner-images/issues/12045
```

[Here](https://github.com/rancher/system-agent-installer-rke2/actions/runs/16329710194)