### PR TITLE
Add errexit to `download` script

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Configure the shell to exit immediately if a command exits with a non-zero
+# status (-e) or if any command in a pipeline fails (-o pipefail).
+set -eo pipefail
 set -x
 
 source $(dirname $0)/version


### PR DESCRIPTION
This modification makes the CI error out when any curl call returns 4XX / 5XX, failing the CI.