### PR TITLE
Remove conditional in `release.yaml` workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,6 @@ jobs:
 
       - name: Publish Image - Staging
         uses: rancher/ecm-distro-tools/actions/publish-image@master
-        if: ${{ contains(github.ref_name, '-rc') }}
         env:
           ARCH: ${{ env.ARCH }}
           OS: ${{ matrix.os }}
@@ -168,7 +167,6 @@ jobs:
 
       - name: Publish Image - Staging
         uses: rancher/ecm-distro-tools/actions/publish-image@master
-        if: ${{ contains(github.ref_name, '-rc') }}
         env:
           ARCH: ${{ matrix.arch }}
           NANOSERVER_VERSION: ${{ matrix.nanoserver-version }}
@@ -248,7 +246,6 @@ jobs:
 
       - name: Publish Manifest - Staging
         uses: rancher/ecm-distro-tools/actions/publish-image@master
-        if: ${{ contains(github.ref_name, '-rc') }}
         with:
           image: ${{ env.IMAGE }}
           tag: ${{ env.GIT_TAG }}
@@ -262,7 +259,6 @@ jobs:
           prime-password: ${{ env.PRIME_STAGING_REGISTRY_PASSWORD }}
 
       - name: Inspect Staging image
-        if: ${{ contains(github.ref_name, '-rc') }}
         run: docker buildx imagetools inspect ${{ env.PRIME_STAGING_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ env.GIT_TAG }}
 
       - name: Publish Manifest - Prime


### PR DESCRIPTION
The current logic doesn't publish GA images to the Staging Registry, with this change it will allow both RC and GA images to be published there.